### PR TITLE
fix: incorrect implementation of templating

### DIFF
--- a/temp-{{ cookiecutter.tool_directory_name }}/unittests/tools/test_{{ cookiecutter.tool_directory_name }}_parser.py
+++ b/temp-{{ cookiecutter.tool_directory_name }}/unittests/tools/test_{{ cookiecutter.tool_directory_name }}_parser.py
@@ -1,20 +1,20 @@
 from django.test import TestCase
-from dojo.tools.{{ cookiecutter.tool_name }}.parser import {{ cookiecutter.tool_name }}Parser
-from dojo.models import Engagement, Product, Test
+from dojo.tools.{{ cookiecutter.tool_directory_name }}.parser import {{ cookiecutter.tool_class_name }}Parser
+from dojo.models import Test
 
 
-class Test{{ cookiecutter.tool_name }}Parser(TestCase):
+class Test{{ cookiecutter.tool_class_name }}Parser(TestCase):
 
-    def test_{{ cookiecutter.tool_name }}_parser_with_no_vuln_has_no_findings(self):
+    def test_{{ cookiecutter.tool_directory_name }}_parser_with_no_vuln_has_no_findings(self):
         testfile = open("dojo/unittests/scans/{{ cookiecutter.tool_directory_name }}/{{ cookiecutter.tool_directory_name }}_zero_vul.{{ cookiecutter.tool_file_type|lower }}")
-        parser = {{ cookiecutter.tool_name }}Parser()
+        parser = {{ cookiecutter.tool_class_name }}Parser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(0, len(findings))
 
-    def test_{{ cookiecutter.tool_name }}_parser_with_one_criticle_vuln_has_one_findings(self):
+    def test_{{ cookiecutter.tool_directory_name }}_parser_with_one_criticle_vuln_has_one_findings(self):
         testfile = open("dojo/unittests/scans/{{ cookiecutter.tool_directory_name }}/{{ cookiecutter.tool_directory_name }}_one_vul.{{ cookiecutter.tool_file_type|lower }}")
-        parser = {{ cookiecutter.tool_name }}Parser()
+        parser = {{ cookiecutter.tool_class_name }}Parser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         for finding in findings:
@@ -24,9 +24,9 @@ class Test{{ cookiecutter.tool_name }}Parser(TestCase):
         self.assertEqual("handlebars", findings[0].component_name)
         self.assertEqual("4.5.2", findings[0].component_version)
 
-    def test_{{ cookiecutter.tool_name }}_parser_with_many_vuln_has_many_findings(self):
+    def test_{{ cookiecutter.tool_directory_name }}_parser_with_many_vuln_has_many_findings(self):
         testfile = open("dojo/unittests/scans/{{ cookiecutter.tool_directory_name }}/{{ cookiecutter.tool_directory_name }}_many_vul.{{ cookiecutter.tool_file_type|lower }}")
-        parser = {{ cookiecutter.tool_name }}Parser()
+        parser = {{ cookiecutter.tool_class_name }}Parser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         for finding in findings:
@@ -34,10 +34,10 @@ class Test{{ cookiecutter.tool_name }}Parser(TestCase):
                 endpoint.clean()
         self.assertEqual(3, len(findings))
 
-    def test_{{ cookiecutter.tool_name }}_parser_empty_with_error(self):
+    def test_{{ cookiecutter.tool_directory_name }}_parser_empty_with_error(self):
         with self.assertRaises(ValueError) as context:
             testfile = open("dojo/unittests/scans/{{ cookiecutter.tool_directory_name }}/empty_with_error.{{ cookiecutter.tool_file_type|lower }}")
-            parser = {{ cookiecutter.tool_name }}Parser()
+            parser = {{ cookiecutter.tool_class_name }}Parser()
             findings = parser.get_findings(testfile, Test())
             testfile.close()
             for finding in findings:


### PR DESCRIPTION
This PR would fix the template result with unittest templating.

```console
❯ cookiecutter https://github.com/DefectDojo/cookiecutter-scanner-parser
You've downloaded /Users/bwangsutthit/.cookiecutters/cookiecutter-scanner-parser before. Is it okay to delete and re-download it? [yes]: yes   
tool_name [My Scanner]: GitLab Secret Detection Report
tool_directory_name [gitlab_secret_detection_report]: 
tool_class_name [GitLabSecretDetectionReport]: GitlabSecretDetectionReport
tool_description [ My scanner is for ....]: 
Select tool_type:
1 - Static
2 - Dynamic
Choose from 1, 2 [1]: 1
Select tool_file_type:
1 - CSV
2 - JSON
3 - XML
Choose from 1, 2, 3 [1]: 2
```

would resulted in

```python
from django.test import TestCase
from dojo.tools.GitLab Secret Detection Report.parser import GitLab Secret Detection ReportParser
from dojo.models import Engagement, Product, Test


class TestGitLab Secret Detection ReportParser(TestCase):

    def test_GitLab Secret Detection Report_parser_with_no_vuln_has_no_findings(self):
        testfile = open("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_zero_vul.json")
        parser = GitLab Secret Detection ReportParser()
        findings = parser.get_findings(testfile, Test())
        testfile.close()
        self.assertEqual(0, len(findings))

    def test_GitLab Secret Detection Report_parser_with_one_criticle_vuln_has_one_findings(self):
        testfile = open("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_one_vul.json")
        parser = GitLab Secret Detection ReportParser()
        findings = parser.get_findings(testfile, Test())
        testfile.close()
        for finding in findings:
            for endpoint in finding.unsaved_endpoints:
                endpoint.clean()
        self.assertEqual(1, len(findings))
        self.assertEqual("handlebars", findings[0].component_name)
        self.assertEqual("4.5.2", findings[0].component_version)

    def test_GitLab Secret Detection Report_parser_with_many_vuln_has_many_findings(self):
        testfile = open("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_many_vul.json")
        parser = GitLab Secret Detection ReportParser()
        findings = parser.get_findings(testfile, Test())
        testfile.close()
        for finding in findings:
            for endpoint in finding.unsaved_endpoints:
                endpoint.clean()
        self.assertEqual(3, len(findings))

    def test_GitLab Secret Detection Report_parser_empty_with_error(self):
        with self.assertRaises(ValueError) as context:
            testfile = open("dojo/unittests/scans/gitlab_secret_detection_report/empty_with_error.json")
            parser = GitLab Secret Detection ReportParser()
            findings = parser.get_findings(testfile, Test())
            testfile.close()
            for finding in findings:
                for endpoint in finding.unsaved_endpoints:
                    endpoint.clean()
            self.assertTrue(
                "GitLab Secret Detection Report report contains errors:" in str(context.exception)
            )
            self.assertTrue("ECONNREFUSED" in str(context.exception))
```